### PR TITLE
Persist managed apps list between runs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,23 @@
+use std::env;
+use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use serde::Deserialize;
+
 use plist::Value;
-use wry::http::Request;
+use serde::{Deserialize, Serialize};
 use tao::event::{Event, WindowEvent};
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
 use tao::window::WindowBuilder;
-use wry::{WebView, WebViewBuilder};
+use wry::{DragDropEvent, WebView, WebViewBuilder, http::Request};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ManagedApp {
     path: PathBuf,
 }
 
 #[derive(Debug)]
 enum UserEvent {
+    Add(PathBuf),
     Restore(PathBuf),
 }
 
@@ -43,8 +47,122 @@ fn restore_dock_icon(app: &Path) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn is_app_bundle(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("app"))
+        .unwrap_or(false)
+}
+
 fn js_add_app(path: &str) -> String {
     format!("addApp({});", serde_json::to_string(path).unwrap())
+}
+
+fn persistence_path() -> Option<PathBuf> {
+    env::var_os("HOME").map(PathBuf::from).map(|mut home| {
+        home.push(".dock_dodger_apps.json");
+        home
+    })
+}
+
+fn persist_apps(apps: &[ManagedApp]) {
+    let Some(path) = persistence_path() else {
+        println!("[Persist] 未找到 HOME 环境变量，无法保存列表。");
+        return;
+    };
+
+    let payload: Vec<PathBuf> = apps.iter().map(|app| app.path.clone()).collect();
+    match serde_json::to_string_pretty(&payload) {
+        Ok(json) => {
+            if let Err(err) = fs::write(&path, json) {
+                println!(
+                    "[Persist] 写入历史记录失败：{}，路径：{}",
+                    err,
+                    path.display()
+                );
+            } else {
+                println!(
+                    "[Persist] 已保存 {} 个程序到 {}",
+                    payload.len(),
+                    path.display()
+                );
+            }
+        }
+        Err(err) => println!("[Persist] 序列化历史记录失败：{}", err),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PersistedEntry {
+    Path(PathBuf),
+    Object { path: PathBuf },
+}
+
+impl PersistedEntry {
+    fn into_path(self) -> PathBuf {
+        match self {
+            PersistedEntry::Path(path) => path,
+            PersistedEntry::Object { path } => path,
+        }
+    }
+}
+
+fn load_persisted_apps() -> (Vec<ManagedApp>, bool) {
+    let mut apps = Vec::new();
+    let mut needs_save = false;
+
+    let Some(path) = persistence_path() else {
+        println!("[Persist] 未找到 HOME 环境变量，跳过历史记录恢复。");
+        return (apps, needs_save);
+    };
+
+    match fs::read_to_string(&path) {
+        Ok(content) => match serde_json::from_str::<Vec<PersistedEntry>>(&content) {
+            Ok(entries) => {
+                for entry in entries {
+                    let path = entry.into_path();
+                    if !path.exists() {
+                        println!("[Persist] 路径不存在，忽略：{}", path.display());
+                        needs_save = true;
+                        continue;
+                    }
+
+                    if !is_app_bundle(&path) {
+                        println!(
+                            "[Persist] 历史记录中发现非 .app 条目，忽略：{}",
+                            path.display()
+                        );
+                        needs_save = true;
+                        continue;
+                    }
+
+                    println!("[Persist] 恢复已隐藏的程序：{}", path.display());
+                    apps.push(ManagedApp { path });
+                }
+            }
+            Err(err) => {
+                println!(
+                    "[Persist] 解析历史记录失败：{}，路径：{}",
+                    err,
+                    path.display()
+                );
+            }
+        },
+        Err(err) => {
+            if err.kind() == ErrorKind::NotFound {
+                println!("[Persist] 未发现历史记录文件：{}", path.display());
+            } else {
+                println!(
+                    "[Persist] 读取历史记录失败：{}，路径：{}",
+                    err,
+                    path.display()
+                );
+            }
+        }
+    }
+
+    (apps, needs_save)
 }
 
 fn rebuild_list(webview: &WebView, apps: &[ManagedApp]) {
@@ -58,7 +176,10 @@ fn rebuild_list(webview: &WebView, apps: &[ManagedApp]) {
 fn main() {
     let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
     let proxy = event_loop.create_proxy();
-    let window = WindowBuilder::new().with_title("Dock Dodger").build(&event_loop).unwrap();
+    let window = WindowBuilder::new()
+        .with_title("Dock Dodger")
+        .build(&event_loop)
+        .unwrap();
 
     let html = r#"
     <!DOCTYPE html>
@@ -83,38 +204,105 @@ fn main() {
     </html>
     "#;
 
+    let drag_proxy = proxy.clone();
+    let ipc_proxy = proxy.clone();
+
     let webview = WebViewBuilder::new(&window)
         .with_html(html)
+        .with_drag_drop_handler(move |event| {
+            if let DragDropEvent::Drop { paths, .. } = event {
+                for path in paths {
+                    let display = path.display().to_string();
+                    if is_app_bundle(&path) {
+                        println!("[DragDrop] 收到来自 Finder 的 .app：{}", display);
+                        let _ = drag_proxy.send_event(UserEvent::Add(path));
+                    } else {
+                        println!("[DragDrop] 忽略非 .app 文件：{}", display);
+                    }
+                }
+                true
+            } else {
+                false
+            }
+        })
         .with_ipc_handler(move |req: Request<String>| {
             if let Ok(data) = serde_json::from_str::<IpcRequest>(req.body()) {
                 if data.cmd == "restore" {
-                    let _ = proxy.send_event(UserEvent::Restore(PathBuf::from(data.path)));
+                    println!("[IPC] 收到恢复请求：{}", data.path);
+                    let _ = ipc_proxy.send_event(UserEvent::Restore(PathBuf::from(data.path)));
                 }
             }
         })
         .build()
         .unwrap();
 
-    let mut apps: Vec<ManagedApp> = Vec::new();
+    let (mut apps, needs_save) = load_persisted_apps();
+    if needs_save {
+        persist_apps(&apps);
+    }
+    rebuild_list(&webview, &apps);
+
+    fn handle_app_drop(path: PathBuf, apps: &mut Vec<ManagedApp>, webview: &WebView) {
+        let path_display = path.display().to_string();
+        println!("[Add] 处理拖入的路径：{}", path_display);
+
+        if !is_app_bundle(&path) {
+            println!("[Add] 路径不是 .app 包，忽略：{}", path_display);
+            return;
+        }
+
+        if apps.iter().any(|app| app.path == path) {
+            println!("[Add] 已存在记录，忽略重复：{}", path_display);
+            return;
+        }
+
+        match hide_dock_icon(&path) {
+            Ok(_) => {
+                println!("[Add] 成功隐藏 Dock 图标：{}", path_display);
+                apps.push(ManagedApp { path });
+                let _ = webview.evaluate_script(&js_add_app(&path_display));
+                persist_apps(apps);
+            }
+            Err(err) => {
+                println!("[Add] 隐藏 Dock 图标失败：{}，错误：{}", path_display, err);
+            }
+        }
+    }
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
         match event {
-            Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
-                *control_flow = ControlFlow::Exit
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                println!("[Window] 接收到关闭请求，准备退出。");
+                *control_flow = ControlFlow::Exit;
             }
-            Event::WindowEvent { event: WindowEvent::DroppedFile(path), .. } => {
-                if path.extension().map(|e| e == "app").unwrap_or(false) {
-                    if hide_dock_icon(&path).is_ok() {
-                        apps.push(ManagedApp { path: path.clone() });
-                        let _ = webview.evaluate_script(&js_add_app(path.to_string_lossy().as_ref()));
-                    }
-                }
+            Event::WindowEvent {
+                event: WindowEvent::DroppedFile(path),
+                ..
+            } => {
+                println!("[Window] 收到窗口层面的拖入文件：{}", path.display());
+                handle_app_drop(path, &mut apps, &webview);
+            }
+            Event::UserEvent(UserEvent::Add(path)) => {
+                println!("[Event] 处理 Add 事件：{}", path.display());
+                handle_app_drop(path, &mut apps, &webview);
             }
             Event::UserEvent(UserEvent::Restore(path)) => {
-                if restore_dock_icon(&path).is_ok() {
-                    apps.retain(|a| a.path != path);
-                    rebuild_list(&webview, &apps);
+                let display = path.display().to_string();
+                println!("[Event] 收到 Restore 事件：{}", display);
+                match restore_dock_icon(&path) {
+                    Ok(_) => {
+                        println!("[Restore] 已恢复 Dock 图标：{}", display);
+                        apps.retain(|a| a.path != path);
+                        persist_apps(&apps);
+                        rebuild_list(&webview, &apps);
+                    }
+                    Err(err) => {
+                        println!("[Restore] 恢复 Dock 图标失败：{}，错误：{}", display, err);
+                    }
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary
- 将隐藏的 .app 列表持久化到用户主目录的 `.dock_dodger_apps.json`，启动时恢复并填充界面
- 在添加或恢复程序时同步更新持久化文件并输出日志，保证列表状态一致
- 兼容字符串数组与对象数组两种历史 JSON 结构，避免 MR 合并冲突同时保持持久化能力

## Testing
- `cargo fmt`
- `cargo check` *(失败：缺少系统库 glib-2.0 / gobject-2.0 / gio-2.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d8c56d24832a881eb4eb0671d2ea